### PR TITLE
Initial functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+## PyCharm
+.idea/
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 ## PyCharm
 .idea/
 __pycache__/
+
+## Conda env files
+conda-env/qd-rnaseq/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ All these are handled by a conda environment which can be activated before runni
 The wrapper use two nf-core pipelines, [nf-core/rnaseq](https://nf-co.re/rnaseq) and [nf-core/rnafusion](https://nf-co.re/rnafusion/2.0.0).
 Both pipelines were downloaded using the [nf-core tools suite](https://nf-co.re/tools/).
 
+**Code for installation**
+```
+nf-core download rnaseq --container singularity --outdir /apps/bio/repos/nf-core/nf-core-rnaseq-X.Y.Z
+nf-core download rnafusion --container singularity --outdir /apps/bio/repos/nf-core/nf-core-rnafusion-X.Y.Z
+```
+
 ### nf-core/rnaseq
 
 The pipeline is installed in `/apps/bio/repos/nf-core/nf-core-rnaseq-X.X/`.
@@ -53,7 +59,7 @@ using the env variable `$NXF_SINGULARITY_CACHEDIR`. This is best to have set in 
 Dependencies in the form of reference data and genome index was built using the --build_references flag. 
 In order to be able to build all dependencies, a [COSMIC](https://cancer.sanger.ac.uk/cosmic/) account is required.
 
-Code for installation
+**Code for installation**
 
 ```
 export NXF_SINGULARITY_CACHEDIR="/apps/bio/dependencies/nf-core/singularities"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
 # qd-rnaseq-wrapper
 This is a wrapper for starting nf-core/rnaseq and nf-core/rnafusion on a set of fastq files
+
+## Pipeline installation
+The wrapper use two nf-core pipelines, [nf-core/rnaseq](https://nf-co.re/rnaseq) and [nf-core/rnafusion](https://nf-co.re/rnafusion/2.0.0).
+Both pipelines were downloaded using the [nf-core tools suite](https://nf-co.re/tools/).
+
+### nf-core/rnaseq
+
+The pipeline is installed in `/apps/bio/repos/nf-core/nf-core-rnaseq-X.X/`.
+
+Paths to where singularity images the pipe is dependent on can be found is set
+using the env variable `$NXF_SINGULARITY_CACHEDIR`. This is best to have set in a .bashrc
+
+Code for installation
+
+```
+export NXF_SINGULARITY_CACHEDIR="/apps/bio/dependencies/nf-core/singularities"
+cd /apps/bio/repos/nf-core/nf-core-rnaseq-X.Y/
+nf-core download rnaseq --container singularity
+```
+
+### nf-core/rnafusion
+The pipeline is installed in `/apps/bio/repos/nf-core/nf-core-rnafusion-X.Y.Z/`.
+
+Paths to where singularity images the pipe is dependent on can be found is set
+using the env variable `$NXF_SINGULARITY_CACHEDIR`. This is best to have set in a .bashrc
+
+Dependencies in the form of reference data and genome index was built using the --build_references flag. 
+In order to be able to build all dependencies, a [COSMIC](https://cancer.sanger.ac.uk/cosmic/) account is required.
+
+Code for installation
+
+```
+export NXF_SINGULARITY_CACHEDIR="/apps/bio/dependencies/nf-core/singularities"
+cd /apps/bio/repos/nf-core/nf-core-rnafusion-X.Y.Z/
+nf-core download rnafusion --container singularity
+nextflow /apps/bio/repos/nf-core/nf-core-rnafusion-2.0.0/workflow/main.nf 
+    -c /apps/bio/repos/nf-core-configs/conf/medair.config 
+    -profile singularity,byss 
+    --build_references 
+    --all
+    --genomes_base /apps/bio/dependencies/nf-core/nf-core-rnafusion-X.Y.Z
+    --outdir /apps/bio/dependencies/nf-core/nf-core-rnafusion-X.Y.Z
+    ---cosmic_username <username>
+    --cosmic_passwd <password>  
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # qd-rnaseq-wrapper
 This is a wrapper for starting nf-core/rnaseq and nf-core/rnafusion on a set of fastq files
 
+## Dependencies
+The wrapper itself is written in python and has a few python modules as dependencies. The main dependency is nextflow.
+All these are handled by a conda environment which can be activated before running the wrapper.
+
 ## Pipeline installation
 The wrapper use two nf-core pipelines, [nf-core/rnaseq](https://nf-co.re/rnaseq) and [nf-core/rnafusion](https://nf-co.re/rnafusion/2.0.0).
 Both pipelines were downloaded using the [nf-core tools suite](https://nf-co.re/tools/).

--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ cd /apps/bio/repos/nf-core/nf-core-rnaseq-X.Y/
 nf-core download rnaseq --container singularity
 ```
 
+**Pre-downloaded references**
+
+Some dependencies, such as genome references can be downloaded on the fly using the 
+--genome flag of the rnaseq pipeline. However, this download sometimes takes quite a bit of time, and can cause
+the pipeline to crash in the case of network dropouts.
+
+In order to circumvent this, the references can be downloaded from AWS iGenomes. For this to work you need to
+use the aws s3 tool-suite. The following code snippet shows how to download the fasta, gtf, bed and STARIndex 
+for GRCh38 from NCBI. To construct other download options, use the website [AWS iGenomes](https://ewels.github.io/AWS-iGenomes/).
+
+To use them, specify paths in the config.ini under '[rnaseq-references]'
+
+```
+module load aws-cli/2.7.7
+aws s3 --no-sign-request --region eu-west-1 sync s3://ngi-igenomes/igenomes/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta/ /apps/bio/dependencies/nf-core/igenomes/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta/
+aws s3 --no-sign-request --region eu-west-1 sync s3://ngi-igenomes/igenomes/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/ /apps/bio/dependencies/nf-core/igenomes/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/ --exclude "*" --include "genes.gtf"
+aws s3 --no-sign-request --region eu-west-1 sync s3://ngi-igenomes/igenomes/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/ /apps/bio/dependencies/nf-core/igenomes/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/ --exclude "*" --include "genes.bed"
+aws s3 --no-sign-request --region eu-west-1 sync s3://ngi-igenomes/igenomes/Homo_sapiens/NCBI/GRCh38/Sequence/STARIndex/ /apps/bio/dependencies/nf-core/igenomes/Homo_sapiens/NCBI/GRCh38/Sequence/STARIndex/
+```
+
 ### nf-core/rnafusion
 The pipeline is installed in `/apps/bio/repos/nf-core/nf-core-rnafusion-X.Y.Z/`.
 

--- a/README.md
+++ b/README.md
@@ -45,3 +45,11 @@ nextflow /apps/bio/repos/nf-core/nf-core-rnafusion-2.0.0/workflow/main.nf
     ---cosmic_username <username>
     --cosmic_passwd <password>  
 ```
+
+## Usage
+### Input data
+* The wrapper takes a directory with gzipped fastq files as input. There should only be two files per sample. If there are more, please concatenate them before running the wwrapper
+
+
+## TODO
+* Allow for more than 2 input files per sample

--- a/conda-env/qd-rnaseq.yaml
+++ b/conda-env/qd-rnaseq.yaml
@@ -6,3 +6,4 @@ dependencies:
   - python=3.10.*
   - nextflow=22.*
   - click
+  - nf-core

--- a/conda-env/qd-rnaseq.yaml
+++ b/conda-env/qd-rnaseq.yaml
@@ -3,6 +3,6 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python
-  - nextflow
+  - python=3.10.*
+  - nextflow=22.*
   - click

--- a/conda-env/qd-rnaseq.yaml
+++ b/conda-env/qd-rnaseq.yaml
@@ -1,0 +1,8 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - python
+  - nextflow
+  - click

--- a/config.ini
+++ b/config.ini
@@ -1,2 +1,10 @@
 [general]
 fastq_to_ss_path = /apps/bio/dependencies/nf-core/scripts/fastq_dir_to_samplesheet.py
+
+[nextflow]
+custom_config = /apps/bio/repos/nf-core-configs/conf/medair.config
+rnaseq = /apps/bio/repos/nf-core/nf-core-rnaseq-3.7/workflow/main.nf
+rnafusion = /apps/bio/repos/nf-core/nf-core-rnafusion-2.0.0/workflow/main.nf
+profile = singularity,byss
+genome = GRCh38
+dependencies_fusion = /apps/bio/dependencies/nf-core/nf-core-rnafusion-2.0.0

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,2 @@
+[general]
+fastq_to_ss_path = /apps/bio/dependencies/nf-core/scripts/fastq_dir_to_samplesheet.py

--- a/config.ini
+++ b/config.ini
@@ -8,3 +8,4 @@ rnafusion = /apps/bio/repos/nf-core/nf-core-rnafusion-2.0.0/workflow/main.nf
 profile = singularity,byss
 genome = GRCh38
 dependencies_fusion = /apps/bio/dependencies/nf-core/nf-core-rnafusion-2.0.0
+test_outdir = /home/xlinak/inbox/qd-wrapper-test

--- a/config.ini
+++ b/config.ini
@@ -5,7 +5,13 @@ fastq_to_ss_path = /apps/bio/dependencies/nf-core/scripts/fastq_dir_to_sampleshe
 custom_config = /apps/bio/repos/nf-core-configs/conf/medair.config
 rnaseq = /apps/bio/repos/nf-core/nf-core-rnaseq-3.7/workflow/main.nf
 rnafusion = /apps/bio/repos/nf-core/nf-core-rnafusion-2.0.0/workflow/main.nf
-profile = singularity,byss
+profile = singularity,byss,qd_rnaseq
 genome = GRCh38
 dependencies_fusion = /apps/bio/dependencies/nf-core/nf-core-rnafusion-2.0.0
 test_outdir = /home/xlinak/inbox/qd-wrapper-test
+
+[rnaseq-references]
+fasta = /apps/bio/dependencies/nf-core/igenomes/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta/genome.fa
+gtf = /apps/bio/dependencies/nf-core/igenomes/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/genes.gtf
+bed = /apps/bio/dependencies/nf-core/igenomes/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/genes.bed
+star_index = /apps/bio/dependencies/nf-core/igenomes/Homo_sapiens/NCBI/GRCh38/Sequence/STARIndex/

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -130,7 +130,7 @@ def build_rnaseq_command(config, outdir: str, ss_path: str, testrun=False) -> li
                 "-c",
                 "/apps/bio/repos/nf-core-configs/conf/medair.config",
                 "--outdir",
-                config.get("nextflow", "test_outdir"),
+                os.path.join(config.get("nextflow", "test_outdir"), "rnaseq"),
                 ]]
     else:
         return rnaseq_command
@@ -185,7 +185,7 @@ def build_rnafusion_command(config, outdir: str, ss_path: str, testrun=False) ->
                 "--outdir",
                 config.get("nextflow", "test_outdir"),
                 "--genomes_base",
-                config.get("nextflow", "dependencies_fusion"),
+                os.path.join(config.get("nextflow", "dependencies_fusion"), "rnafusion"),
                 ]]
     else:
         return rnafusion_command

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -79,6 +79,8 @@ def sanitize_fastqdir(fastqdir: str):
     """
     for filename in os.listdir(fastqdir):
         if not filename.endswith(".fastq.gz"):
+            if filename == "samplesheet.csv":
+                continue
             raise Exception(
                 f"Found a file not ending with .fastq.gz in fastq dir: {filename}"
             )

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -78,3 +78,64 @@ def sanitize_fastqdir(fastqdir: str):
             raise Exception(
                 f"Found a file not ending with .fastq.gz in fastq dir: {filename}"
             )
+
+
+def build_rnaseq_command(config: str, outdir: str ,ss_path: str) -> list:
+    rnaseq_command = ['nextflow']
+    # Path to main.nf
+    rnaseq_command.append(config.get("nextflow", "rnaseq"))
+
+    # If custom config, use it
+    if config.get("nextflow", "custom_config"):
+        rnaseq_command.append("-c")
+        rnaseq_command.append(config.get("nextflow", "custom_config"))
+
+    # Profile to use
+    rnaseq_command.append("-profile")
+    rnaseq_command.append(config.get("nextflow", "profile"))
+
+    # Genome version to use
+    rnaseq_command.append("--genome")
+    rnaseq_command.append(config.get("nextflow", "genome"))
+
+    # Input samplesheet.csv
+    rnaseq_command.append("--input")
+    rnaseq_command.append(ss_path)
+
+    # Outdir
+    rnaseq_command.append("--outdir")
+    rnaseq_command.append(os.path.join(outdir, "rnaseq"))
+
+    return rnaseq_command
+
+
+def build_rnafusion_command(config: str, outdir: str ,ss_path: str) -> list:
+    rnafusion_command = ['nextflow']
+    # Path to main.nf
+    rnafusion_command.append(config.get("nextflow", "rnafusion"))
+
+    # If custom config, use it
+    if config.get("nextflow", "custom_config"):
+        rnafusion_command.append("-c")
+        rnafusion_command.append(config.get("nextflow", "custom_config"))
+
+    # Profile to use
+    rnafusion_command.append("-profile")
+    rnafusion_command.append(config.get("nextflow", "profile"))
+
+    # Run alla tools
+    rnafusion_command.append("--all")
+
+    # Path to dependencies
+    rnafusion_command.append("--genomes_base")
+    rnafusion_command.append(config.get("nextflow", "dependencies_fusion"))
+
+    # Input samplesheet.csv
+    rnafusion_command.append("--input")
+    rnafusion_command.append(ss_path)
+
+    # Outdir
+    rnafusion_command.append("--outdir")
+    rnafusion_command.append(os.path.join(outdir, "rnafusion"))
+
+    return rnafusion_command

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -79,7 +79,7 @@ def sanitize_fastqdir(fastqdir: str):
     """
     for filename in os.listdir(fastqdir):
         if not filename.endswith(".fastq.gz"):
-            if filename == "samplesheet.csv":
+            if filename.lower() == "samplesheet.csv":
                 continue
             raise Exception(
                 f"Found a file not ending with .fastq.gz in fastq dir: {filename}"

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -28,6 +28,10 @@ def setup_logger(name, log_path=None):
 
 
 def get_config():
+    """
+    Read in a config.ini file and return the object. Assumes it's located in
+    the wrapper root folder and called config.ini
+    """
     converters = {"list": lambda x: [i.strip() for i in x.split(",")]}
     config = ConfigParser(converters=converters)
 
@@ -42,5 +46,35 @@ def get_config():
     return config
 
 
-def dir_to_samplesheet(scriptpath):
-    subprocess.run(scriptpath)
+def dir_to_samplesheet(scriptpath: str, fastqdir: str, strandedness: str) -> str:
+    """
+    Executes the nf-core fastq_dir_to_samplesheet.py script on a given dir with fastq files
+    """
+    ss_path = os.path.join(fastqdir, "samplesheet.csv")
+    command_args = [
+        "python",
+        scriptpath,
+        fastqdir,
+        ss_path,
+        "--strandedness",
+        strandedness,
+    ]
+
+    try:
+        subprocess.run(command_args)
+    except:
+        raise Exception(f"Could not execute {scriptpath}.")
+
+    return ss_path
+
+
+def sanitize_fastqdir(fastqdir: str):
+    """
+    Checks all files in a given fastq dir that assumptions about naming is met.
+    For now this only checks file endings, but could be expanded to check for samples with more than 2 files.
+    """
+    for filename in os.listdir(fastqdir):
+        if not filename.endswith(".fastq.gz"):
+            raise Exception(
+                f"Found a file not ending with .fastq.gz in fastq dir: {filename}"
+            )

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -94,7 +94,7 @@ def build_rnaseq_command(config, outdir: str, ss_path: str, testrun=False) -> li
     :param outdir: Path to output directory
     :param ss_path: Path to samplesheet.csv
     :param: testrun: Set to true to run test data
-    :return: List with all components of the command
+    :return: List of list with all components of the command
     """
     rnaseq_command = ["nextflow"]
     # Path to main.nf
@@ -122,7 +122,7 @@ def build_rnaseq_command(config, outdir: str, ss_path: str, testrun=False) -> li
     rnaseq_command.append(os.path.join(outdir, "rnaseq"))
 
     if testrun:
-        return [[
+        return [
                 "nextflow",
                 config.get("nextflow", "rnaseq"),
                 "-profile",
@@ -131,7 +131,7 @@ def build_rnaseq_command(config, outdir: str, ss_path: str, testrun=False) -> li
                 "/apps/bio/repos/nf-core-configs/conf/medair.config",
                 "--outdir",
                 os.path.join(config.get("nextflow", "test_outdir"), "rnaseq"),
-                ]]
+                ]
     else:
         return rnaseq_command
 
@@ -144,7 +144,7 @@ def build_rnafusion_command(config, outdir: str, ss_path: str, testrun=False) ->
     :param outdir: Path to output directory
     :param ss_path: Path to samplesheet.csv
     :param: testrun: Set to true to run test data
-    :return: List with all components of the command
+    :return: List of list with all components of the command
     """
     rnafusion_command = ["nextflow"]
     # Path to main.nf
@@ -175,7 +175,7 @@ def build_rnafusion_command(config, outdir: str, ss_path: str, testrun=False) ->
     rnafusion_command.append(os.path.join(outdir, "rnafusion"))
 
     if testrun:
-        return [[
+        return [
                 "nextflow",
                 config.get("nextflow", "rnafusion"),
                 "-c",
@@ -186,6 +186,6 @@ def build_rnafusion_command(config, outdir: str, ss_path: str, testrun=False) ->
                 config.get("nextflow", "test_outdir"),
                 "--genomes_base",
                 os.path.join(config.get("nextflow", "dependencies_fusion"), "rnafusion"),
-                ]]
+                ]
     else:
         return rnafusion_command

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -1,0 +1,46 @@
+import os
+import logging
+from configparser import ConfigParser
+import subprocess
+
+
+def setup_logger(name, log_path=None):
+    """Enables the logging to be setup correctly"""
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+
+    stream_handle = logging.StreamHandler()
+    stream_handle.setLevel(logging.DEBUG)
+    stream_handle.setFormatter(
+        logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    )
+    logger.addHandler(stream_handle)
+
+    if log_path:
+        file_handle = logging.FileHandler(log_path, "a")
+        file_handle.setLevel(logging.DEBUG)
+        file_handle.setFormatter(
+            logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+        )
+        logger.addHandler(file_handle)
+
+    return logger
+
+
+def get_config():
+    converters = {"list": lambda x: [i.strip() for i in x.split(",")]}
+    config = ConfigParser(converters=converters)
+
+    root_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+    config_path = os.path.join(root_path, "config.ini")
+
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"No config found at {config_path}")
+
+    config.read(config_path)
+    return config
+
+
+def dir_to_samplesheet(scriptpath):
+    subprocess.run(scriptpath)

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -49,6 +49,10 @@ def get_config():
 def dir_to_samplesheet(scriptpath: str, fastqdir: str, strandedness: str) -> str:
     """
     Executes the nf-core fastq_dir_to_samplesheet.py script on a given dir with fastq files
+    :param scriptpath: Path to fastq_dir_to_samplesheet.py
+    :param fastqdir: Path to directory with fastq files
+    :param strandedness: Strandedness of library
+    :return: Path to the generated samplesheet.csv
     """
     ss_path = os.path.join(fastqdir, "samplesheet.csv")
     command_args = [
@@ -80,8 +84,17 @@ def sanitize_fastqdir(fastqdir: str):
             )
 
 
-def build_rnaseq_command(config: str, outdir: str ,ss_path: str) -> list:
-    rnaseq_command = ['nextflow']
+def build_rnaseq_command(config, outdir: str, ss_path: str, testrun=False) -> list:
+    """
+    Create a list with the nextflow commands to send to subprocess
+
+    :param config: configparser object with configurations
+    :param outdir: Path to output directory
+    :param ss_path: Path to samplesheet.csv
+    :param: testrun: Set to true to run test data
+    :return: List with all components of the command
+    """
+    rnaseq_command = ["nextflow"]
     # Path to main.nf
     rnaseq_command.append(config.get("nextflow", "rnaseq"))
 
@@ -106,11 +119,32 @@ def build_rnaseq_command(config: str, outdir: str ,ss_path: str) -> list:
     rnaseq_command.append("--outdir")
     rnaseq_command.append(os.path.join(outdir, "rnaseq"))
 
-    return rnaseq_command
+    if testrun:
+        return [[
+                "nextflow",
+                config.get("nextflow", "rnaseq"),
+                "-profile",
+                "singularity,byss,test",
+                "-c",
+                "/apps/bio/repos/nf-core-configs/conf/medair.config",
+                "--outdir",
+                config.get("nextflow", "test_outdir"),
+                ]]
+    else:
+        return rnaseq_command
 
 
-def build_rnafusion_command(config: str, outdir: str ,ss_path: str) -> list:
-    rnafusion_command = ['nextflow']
+def build_rnafusion_command(config, outdir: str, ss_path: str, testrun=False) -> list:
+    """
+    Create a list with the nextflow commands to send to subprocess
+
+    :param config: configparser object with configurations
+    :param outdir: Path to output directory
+    :param ss_path: Path to samplesheet.csv
+    :param: testrun: Set to true to run test data
+    :return: List with all components of the command
+    """
+    rnafusion_command = ["nextflow"]
     # Path to main.nf
     rnafusion_command.append(config.get("nextflow", "rnafusion"))
 
@@ -138,4 +172,18 @@ def build_rnafusion_command(config: str, outdir: str ,ss_path: str) -> list:
     rnafusion_command.append("--outdir")
     rnafusion_command.append(os.path.join(outdir, "rnafusion"))
 
-    return rnafusion_command
+    if testrun:
+        return [[
+                "nextflow",
+                config.get("nextflow", "rnafusion"),
+                "-c",
+                "/apps/bio/repos/nf-core-configs/conf/medair.config",
+                "-profile",
+                "singularity,byss,test",
+                "--outdir",
+                config.get("nextflow", "test_outdir"),
+                "--genomes_base",
+                config.get("nextflow", "dependencies_fusion"),
+                ]]
+    else:
+        return rnafusion_command

--- a/wrapper.py
+++ b/wrapper.py
@@ -44,6 +44,14 @@ def main(fastqdir, outdir, strandedness):
         logger.error(e)
         sys.exit(1)
 
+    # Start pipelines
+    # Start rnaseq
+    rnaseq_command = []
+    nextflow_config = config.get("nextflow", "custom_config")
+
+
+    #Start rnafusion
+
 
 if __name__ == "__main__":
     main()

--- a/wrapper.py
+++ b/wrapper.py
@@ -7,6 +7,8 @@ from tools.helpers import (
     get_config,
     dir_to_samplesheet,
     sanitize_fastqdir,
+    build_rnaseq_command,
+    build_rnafusion_command,
 )
 
 
@@ -45,12 +47,10 @@ def main(fastqdir, outdir, strandedness):
         sys.exit(1)
 
     # Start pipelines
-    # Start rnaseq
-    rnaseq_command = []
-    nextflow_config = config.get("nextflow", "custom_config")
-
-
-    #Start rnafusion
+    # Build the rnaseq command
+    rnaseq_command = build_rnaseq_command(config, outdir, ss_path)
+    # Build the rnafusion command
+    rnafusion_command = build_rnafusion_command(config, outdir, ss_path)
 
 
 if __name__ == "__main__":

--- a/wrapper.py
+++ b/wrapper.py
@@ -61,13 +61,13 @@ def main(fastqdir, outdir, strandedness, testrun, skip_rnaseq, skip_rnafusion):
     if not skip_rnaseq:
         logger.info("Starting the nf-core/rnaseq pipeline")
         rnaseq_command = build_rnaseq_command(config, outdir, ss_path, testrun)
-        threads.append(threading.Thread(target=call_script, args=rnaseq_command))
+        threads.append(threading.Thread(target=call_script, args=[rnaseq_command]))
 
     # Build the rnafusion command and add to threads
     if not skip_rnafusion:
         logger.info("Starting the nf-core/rnafusion pipeline")
         rnafusion_command = build_rnafusion_command(config, outdir, ss_path, testrun)
-        threads.append(threading.Thread(target=call_script, args=rnafusion_command))
+        threads.append(threading.Thread(target=call_script, args=[rnafusion_command]))
 
     # Start both pipelines in parallel
     for t in threads:

--- a/wrapper.py
+++ b/wrapper.py
@@ -23,7 +23,8 @@ from tools.helpers import (
 @click.option("--testrun", is_flag=True, help="Run with nf-core test data")
 @click.option("--skip-rnaseq", is_flag=True, help="Skip the nf-core/rnaseq pipeline")
 @click.option("--skip-rnafusion", is_flag=True, help="Skip the nf-core/rnafusion pipeline")
-def main(fastqdir, outdir, strandedness, testrun, skip_rnaseq, skip_rnafusion):
+@click.option("--save-reference", is_flag=True, help="Save the genome references in outfolder")
+def main(fastqdir, outdir, strandedness, testrun, skip_rnaseq, skip_rnafusion, save_reference):
     # Set up the logger function
     now = datetime.datetime.now()
     logfile = os.path.join(outdir, "QD-rnaseq" + now.strftime("%y%m%d_%H%M%S") + ".log")
@@ -60,7 +61,7 @@ def main(fastqdir, outdir, strandedness, testrun, skip_rnaseq, skip_rnafusion):
     # Build the rnaseq command and add to threads
     if not skip_rnaseq:
         logger.info("Starting the nf-core/rnaseq pipeline")
-        rnaseq_command = build_rnaseq_command(config, outdir, ss_path, testrun)
+        rnaseq_command = build_rnaseq_command(config, outdir, ss_path, testrun, save_reference)
         threads.append(threading.Thread(target=call_script, args=[rnaseq_command]))
 
     # Build the rnafusion command and add to threads

--- a/wrapper.py
+++ b/wrapper.py
@@ -1,0 +1,26 @@
+import os
+import click
+import datetime
+from tools.helpers import setup_logger, get_config
+
+@click.command()
+@click.option("--fastqdir", required=True, help="Path to input directory of fastq files"
+)
+@click.option("--outdir", required=True, help="Path to output directory"
+)
+def main(fastqdir, outdir):
+    # Set up the logger function
+    now = datetime.datetime.now()
+    logfile = os.path.join(
+        outdir, "QD-rnaseq" + now.strftime("%y%m%d_%H%M%S") + ".log"
+    )
+    #logger = setup_logger("qd-rnaseq", logfile)
+    logger = setup_logger("qd-rnaseq") ## TODO, remove to enable logpath
+    logger.info("Starting the RNAseq pipepline wrapper.")
+
+    # Read in the config
+    logger.info(f"Reading parameters from config.ini")
+    config = get_config()
+
+if __name__ == "__main__":
+    main()

--- a/wrapper.py
+++ b/wrapper.py
@@ -1,26 +1,49 @@
 import os
+import sys
 import click
 import datetime
-from tools.helpers import setup_logger, get_config
+from tools.helpers import (
+    setup_logger,
+    get_config,
+    dir_to_samplesheet,
+    sanitize_fastqdir,
+)
+
 
 @click.command()
-@click.option("--fastqdir", required=True, help="Path to input directory of fastq files"
+@click.option(
+    "--fastqdir", required=True, help="Path to input directory of fastq files"
 )
-@click.option("--outdir", required=True, help="Path to output directory"
-)
-def main(fastqdir, outdir):
+@click.option("--outdir", required=True, help="Path to output directory")
+@click.option("--strandedness", default="reverse", help="Strandedness of seq libraries")
+def main(fastqdir, outdir, strandedness):
     # Set up the logger function
     now = datetime.datetime.now()
-    logfile = os.path.join(
-        outdir, "QD-rnaseq" + now.strftime("%y%m%d_%H%M%S") + ".log"
-    )
-    #logger = setup_logger("qd-rnaseq", logfile)
-    logger = setup_logger("qd-rnaseq") ## TODO, remove to enable logpath
+    logfile = os.path.join(outdir, "QD-rnaseq" + now.strftime("%y%m%d_%H%M%S") + ".log")
+    # logger = setup_logger("qd-rnaseq", logfile)
+    logger = setup_logger("qd-rnaseq")  ## TODO, remove to enable logpath
     logger.info("Starting the RNAseq pipepline wrapper.")
 
     # Read in the config
     logger.info(f"Reading parameters from config.ini")
     config = get_config()
+
+    # Make sure fastqdir looks good
+    try:
+        sanitize_fastqdir(fastqdir)
+    except Exception as e:
+        logger.error(e)
+        sys.exit(1)
+
+    # Make samplesheet from fastq dir
+    logger.info(f"Creating samplesheet.csv from {fastqdir}")
+    scriptpath = config.get("general", "fastq_to_ss_path")
+    try:
+        ss_path = dir_to_samplesheet(scriptpath, fastqdir, strandedness)
+    except Exception as e:
+        logger.error(e)
+        sys.exit(1)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Introduction 
This is the start of the quick-and-dirty wrapper for running the nf.core/rnaseq and nf-core/rnafusion pipelines on rnaseq samples. This PR contains just the start of the wrapper, so it is quite barebones right now. Would be great to get some feedback on the code in general, and if you could test it

## To test
Any RNAseq dataset can be used. The samples starting with H2* in `/seqstore/remote/outbox/research_projects/G21-020/shared/220120_A00687_0176_BHLTT3DRXY`can be used. If you have other data please use it as it would be good to see.

Make a folder with fastq files (can probably be symlinks) somewhere, as the wrapper as for now takes a folder with fastq files as input.

A conda environment with dependencies can be built from the `conda.-env/qd-rnaseq.yaml` file.

Instead of using actual data, one can also run the test suite. **However,** if you do, please change the `test_outdir` in the config.ini

### Test cheatsheet
```
git clone git@github.com:ClinicalGenomicsGBG/qd-rnaseq-wrapper.git
cd qd-rnaseq-wrapper
git fetch --all
git checkout  init_func

conda env create -f conda-env/qd-rnaseq.yaml -p conda-env/qd-rnaseq
conda deactivate
conda activate conda-env/qd-rnaseq

mkdir fastqdir
ln -s /seqstore/remote/outbox/research_projects/G21-020/shared/220120_A00687_0176_BHLTT3DRXY/H2* fastqdir/
python wrapper.py --fastqdir ./fastqdir --outdir ./outfolder
```