### PR TITLE
Better logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ __pycache__/
 
 ## Conda env files
 conda-env/qd-rnaseq/
+
+## Nextflow
+.nextflow*
+work/

--- a/config.ini
+++ b/config.ini
@@ -6,8 +6,9 @@ custom_config = /apps/bio/repos/nf-core-configs/conf/medair.config
 rnaseq = /apps/bio/repos/nf-core/nf-core-rnaseq-3.7/workflow/main.nf
 rnafusion = /apps/bio/repos/nf-core/nf-core-rnafusion-2.0.0/workflow/main.nf
 profile = singularity,byss,qd_rnaseq
+test_profile = singularity,byss,test
 genome = GRCh38
-dependencies_fusion = /apps/bio/dependencies/nf-core/nf-core-rnafusion-2.0.0
+dependencies_fusion = /apps/bio/dependencies/nf-core
 test_outdir = /home/xlinak/inbox/qd-wrapper-test
 
 [rnaseq-references]

--- a/config.ini
+++ b/config.ini
@@ -3,7 +3,7 @@ fastq_to_ss_path = /apps/bio/dependencies/nf-core/scripts/fastq_dir_to_sampleshe
 
 [nextflow]
 custom_config = /apps/bio/repos/nf-core-configs/conf/medair.config
-rnaseq = /apps/bio/repos/nf-core/nf-core-rnaseq-3.7/workflow/main.nf
+rnaseq = /apps/bio/repos/nf-core/nf-core-rnaseq-3.8.1/workflow/main.nf
 rnafusion = /apps/bio/repos/nf-core/nf-core-rnafusion-2.0.0/workflow/main.nf
 profile = singularity,byss,qd_rnaseq
 test_profile = singularity,byss,test

--- a/config.ini
+++ b/config.ini
@@ -8,7 +8,7 @@ rnafusion = /apps/bio/repos/nf-core/nf-core-rnafusion-2.0.0/workflow/main.nf
 profile = singularity,byss,qd_rnaseq
 test_profile = singularity,byss,test
 genome = GRCh38
-dependencies_fusion = /apps/bio/dependencies/nf-core
+dependencies_fusion = /apps/bio/dependencies/nf-core/nf-core-rnafusion-2.0.0
 test_outdir = /home/xlinak/inbox/qd-wrapper-test
 
 [rnaseq-references]

--- a/wrapper.py
+++ b/wrapper.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import click
+import rich_click as click
 import datetime
 import threading
 import subprocess


### PR DESCRIPTION
### Improved logging
This PR will improve the logging by better messages for the wrapper log as well as collecting the two nextflow logs in their respective outputfolder. 

The functionality using execution reports have also been turned on. This produces a report in the end showing how much compute resources are used in each step. this could be useful to guide further optimisations.

**Other**
- Updated version of nf-core/rnaseq to 3.8.1
- Test profile for cleaner start of testruns
- Now uses [rich-click](https://github.com/ewels/rich-click) 

Don't think we need to run a test-suite on this, but please do have a look at the code for anything weird or improvements you can see.