### PR TITLE
Optimise one

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@ All these are handled by a conda environment which can be activated before runni
 The wrapper use two nf-core pipelines, [nf-core/rnaseq](https://nf-co.re/rnaseq) and [nf-core/rnafusion](https://nf-co.re/rnafusion/2.0.0).
 Both pipelines were downloaded using the [nf-core tools suite](https://nf-co.re/tools/).
 
-**Code for installation**
-```
-nf-core download rnaseq --container singularity --outdir /apps/bio/repos/nf-core/nf-core-rnaseq-X.Y.Z
-nf-core download rnafusion --container singularity --outdir /apps/bio/repos/nf-core/nf-core-rnafusion-X.Y.Z
-```
-
 ### nf-core/rnaseq
 
 The pipeline is installed in `/apps/bio/repos/nf-core/nf-core-rnaseq-X.X/`.

--- a/conda-env/qd-rnaseq.yaml
+++ b/conda-env/qd-rnaseq.yaml
@@ -5,5 +5,5 @@ channels:
 dependencies:
   - python=3.10.*
   - nextflow=22.*
-  - click
+  - rich-click
   - nf-core

--- a/config.ini
+++ b/config.ini
@@ -7,7 +7,7 @@ profile = singularity,byss,qd_rnaseq
 test_profile = singularity,byss,test
 
 [rnafusion]
-rnafusion = /apps/bio/repos/nf-core/nf-core-rnafusion-2.0.0/workflow/main.nf
+main = /apps/bio/repos/nf-core/nf-core-rnafusion-2.0.0/workflow/main.nf
 #rnafusion = /home/xlinak/repos/rnafusion/main.nf
 dependencies_fusion = /apps/bio/dependencies/nf-core/nf-core-rnafusion-2.0.0
 fusionreport_tool_cutoff = 1
@@ -20,5 +20,5 @@ aligner = star_rsem
 [rnaseq-references]
 fasta = /apps/bio/dependencies/nf-core/igenomes/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta/genome.fa
 gtf = /apps/bio/dependencies/nf-core/igenomes/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/genes.gtf
-bed = /apps/bio/dependencies/nf-core/igenomes/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/genes.bed
+gene_bed = /apps/bio/dependencies/nf-core/igenomes/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/genes.bed
 star_index = /apps/bio/dependencies/nf-core/igenomes/Homo_sapiens/NCBI/GRCh38/Sequence/STARIndex/

--- a/config.ini
+++ b/config.ini
@@ -2,7 +2,7 @@
 fastq_to_ss_path = /apps/bio/dependencies/nf-core/scripts/fastq_dir_to_samplesheet.py
 
 [nextflow]
-custom_config = /apps/bio/repos/nf-core-configs/conf/medair.config
+#custom_config = /apps/bio/repos/nf-core-configs/conf/medair.config
 profile = singularity,byss,qd_rnaseq
 test_profile = singularity,byss,test
 

--- a/config.ini
+++ b/config.ini
@@ -3,13 +3,19 @@ fastq_to_ss_path = /apps/bio/dependencies/nf-core/scripts/fastq_dir_to_sampleshe
 
 [nextflow]
 custom_config = /apps/bio/repos/nf-core-configs/conf/medair.config
-rnaseq = /apps/bio/repos/nf-core/nf-core-rnaseq-3.8.1/workflow/main.nf
-rnafusion = /apps/bio/repos/nf-core/nf-core-rnafusion-2.0.0/workflow/main.nf
 profile = singularity,byss,qd_rnaseq
 test_profile = singularity,byss,test
-genome = GRCh38
+
+[rnafusion]
+rnafusion = /apps/bio/repos/nf-core/nf-core-rnafusion-2.0.0/workflow/main.nf
+#rnafusion = /home/xlinak/repos/rnafusion/main.nf
 dependencies_fusion = /apps/bio/dependencies/nf-core/nf-core-rnafusion-2.0.0
-test_outdir = /home/xlinak/inbox/qd-wrapper-test
+fusionreport_tool_cutoff = 1
+
+[rnaseq]
+main = /apps/bio/repos/nf-core/nf-core-rnaseq-3.8.1/workflow/main.nf
+genome = GRCh38
+aligner = star_rsem
 
 [rnaseq-references]
 fasta = /apps/bio/dependencies/nf-core/igenomes/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta/genome.fa

--- a/qd-wrapper_nextflow.config
+++ b/qd-wrapper_nextflow.config
@@ -1,0 +1,116 @@
+//Profile config names for nf-core/configs
+params {
+  config_profile_description = 'Cluster profile for medair (local cluster of Clinical Genomics Gothenburg)'
+  config_profile_contact = 'Clinical Genomics, Gothenburg'
+  config_profile_url = 'https://www.scilifelab.se/units/clinical-genomics-goteborg/'
+}
+
+//Nextflow parameters
+singularity {
+    enabled = true
+}
+
+profiles {
+  
+  clinic {
+    process {
+      queue = 'wgs.q'
+      executor = 'sge'
+      penv = 'mpi'
+      process.clusterOptions = '-l excl=1'
+      params.max_cpus = 40
+      params.max_time = 48.h
+      params.max_memory = 128.GB
+    }
+  }
+
+  research {
+    process {
+      queue = 'batch.q'
+      executor = 'sge'
+      penv = 'mpi'
+      process.clusterOptions = '-l excl=1'
+      params.max_cpus = 40
+      params.max_time = 480.h
+      params.max_memory = 128.GB
+    }
+  }
+
+  byss {
+    process {
+      queue = 'test.q'
+      executor = 'sge'
+      penv = 'mpi'
+      process.clusterOptions = '-l excl=1'
+      params.max_cpus = 40
+      params.max_time = 480.h
+      params.max_memory = 128.GB
+    }
+  }
+
+  qd_rnaseq {
+    process {
+      cpus   = { check_max( 1    * task.attempt, 'cpus'   ) }
+      memory = { check_max( 6.GB * task.attempt, 'memory' ) }
+
+      errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'retry' : 'finish' }
+      maxRetries    = 2
+      maxErrors     = '-1'
+
+      // Process-specific resource requirements
+      withLabel:process_low {
+        cpus   = { check_max( 2     * task.attempt, 'cpus'    ) }
+        memory = { check_max( 12.GB * task.attempt, 'memory'  ) }
+        time   = { check_max( 4.h   * task.attempt, 'time'    ) }
+        }
+     withLabel:process_medium {
+       cpus   = { check_max( 12    * task.attempt, 'cpus'    ) }
+       memory = { check_max( 36.GB * task.attempt, 'memory'  ) }
+       time   = { check_max( 8.h   * task.attempt, 'time'    ) }
+       }
+     withLabel:process_high {
+       cpus   = { check_max( 40    * task.attempt, 'cpus'    ) }
+       memory = { check_max( 72.GB * task.attempt, 'memory'  ) }
+       time   = { check_max( 16.h  * task.attempt, 'time'    ) }
+       }
+     withLabel:process_long {
+       time   = { check_max( 20.h  * task.attempt, 'time'    ) }
+       }
+    }
+  }
+
+}
+
+
+// Function to ensure that resource requirements don't go beyond
+// a maximum limit
+def check_max(obj, type) {
+    if (type == 'memory') {
+        try {
+            if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
+                return params.max_memory as nextflow.util.MemoryUnit
+            else
+                return obj
+        } catch (all) {
+            println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
+            return obj
+        }
+    } else if (type == 'time') {
+        try {
+            if (obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
+                return params.max_time as nextflow.util.Duration
+            else
+                return obj
+        } catch (all) {
+            println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
+            return obj
+        }
+    } else if (type == 'cpus') {
+        try {
+            return Math.min( obj, params.max_cpus as int )
+        } catch (all) {
+            println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
+            return obj
+        }
+    }
+}

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -127,7 +127,6 @@ def build_rnaseq_command(
     else:
         rnaseq_command.append(config.get("nextflow", "profile"))
 
-
     # Pre-downloaded references, or download from iGenomes
     if config.has_section("rnaseq-references") and not save_reference and not testrun:
         for option in config.options("rnaseq-references"):
@@ -136,6 +135,13 @@ def build_rnaseq_command(
     else:
         rnaseq_command.append("--genome")
         rnaseq_command.append(config.get("rnaseq", "genome"))
+
+    # Aligner to use
+    rnaseq_command.append("--aligner")
+    rnaseq_command.append(config.get("rnaseq", "aligner"))
+    #Add salmon if not using the star_salmon option
+    if config.get("rnaseq", "aligner") != 'star_salmon':
+        rnaseq_command.append("--pseudo_aligner salmon")
 
     # Input samplesheet.csv
     if not testrun:

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -89,7 +89,12 @@ def sanitize_fastqdir(fastqdir: str):
 
 
 def build_rnaseq_command(
-    config, outdir: str, logdir: str, ss_path: str, testrun=False, save_reference=False
+    config,
+    outdir: str,
+    logdir: str,
+    ss_path: str,
+    testrun=False,
+    save_reference=False,
 ) -> dict:
     """
     Create a list with the nextflow commands to send to subprocess
@@ -120,10 +125,19 @@ def build_rnaseq_command(
     if config.has_option("nextflow", "custom_config"):
         rnaseq_command.append("-c")
         rnaseq_command.append(config.get("nextflow", "custom_config"))
-    elif os.path.isfile(os.path.join(os.path.dirname(sys.modules['__main__'].__file__), "qd-wrapper_nextflow.config")):
+    elif os.path.isfile(
+        os.path.join(
+            os.path.dirname(sys.modules["__main__"].__file__),
+            "qd-wrapper_nextflow.config",
+        )
+    ):
         rnaseq_command.append("-c")
-        rnaseq_command.append(os.path.join(os.path.dirname(sys.modules['__main__'].__file__), "qd-wrapper_nextflow.config"))
-
+        rnaseq_command.append(
+            os.path.join(
+                os.path.dirname(sys.modules["__main__"].__file__),
+                "qd-wrapper_nextflow.config",
+            )
+        )
 
     # Profile to use
     rnaseq_command.append("-profile")
@@ -145,7 +159,7 @@ def build_rnaseq_command(
     rnaseq_command.append("--aligner")
     rnaseq_command.append(config.get("rnaseq", "aligner"))
     # Add salmon if not using the star_salmon option
-    if config.get("rnaseq", "aligner") != 'star_salmon':
+    if config.get("rnaseq", "aligner") != "star_salmon":
         rnaseq_command.append("--pseudo_aligner")
         rnaseq_command.append("salmon")
 
@@ -161,9 +175,16 @@ def build_rnaseq_command(
     if save_reference:
         rnaseq_command.append("--save_reference")
 
-    return {'nf-core/rnaseq': rnaseq_command}
+    return {"nf-core/rnaseq": rnaseq_command}
 
-def build_rnafusion_command(config, outdir: str, logdir: str, ss_path: str, testrun=False) -> dict:
+
+def build_rnafusion_command(
+    config,
+    outdir: str,
+    logdir: str,
+    ss_path: str,
+    testrun=False,
+) -> dict:
     """
     Create a list with the nextflow commands to send to subprocess
 
@@ -194,9 +215,19 @@ def build_rnafusion_command(config, outdir: str, logdir: str, ss_path: str, test
     if config.has_option("nextflow", "custom_config"):
         rnafusion_command.append("-c")
         rnafusion_command.append(config.get("nextflow", "custom_config"))
-    elif os.path.isfile(os.path.join(os.path.dirname(sys.modules['__main__'].__file__), "qd-wrapper_nextflow.config")):
+    elif os.path.isfile(
+        os.path.join(
+            os.path.dirname(sys.modules["__main__"].__file__),
+            "qd-wrapper_nextflow.config",
+        )
+    ):
         rnafusion_command.append("-c")
-        rnafusion_command.append(os.path.join(os.path.dirname(sys.modules['__main__'].__file__), "qd-wrapper_nextflow.config"))
+        rnafusion_command.append(
+            os.path.join(
+                os.path.dirname(sys.modules["__main__"].__file__),
+                "qd-wrapper_nextflow.config",
+            )
+        )
 
     # Profile to use
     rnafusion_command.append("-profile")
@@ -228,7 +259,7 @@ def build_rnafusion_command(config, outdir: str, logdir: str, ss_path: str, test
     rnafusion_command.append("--outdir")
     rnafusion_command.append(os.path.join(outdir, "rnafusion"))
 
-    return {'nf-core/rnafusion': rnafusion_command}
+    return {"nf-core/rnafusion": rnafusion_command}
 
 
 def start_pipe_threads(pipe_dict: dict, logger):

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import logging
 from configparser import ConfigParser
 import subprocess
@@ -116,9 +117,13 @@ def build_rnaseq_command(
     rnaseq_command.append(os.path.join(logdir, "rnaseq", "rnaseq-execution.html"))
 
     # If custom config, use it
-    if config.get("nextflow", "custom_config"):
+    if config.has_option("nextflow", "custom_config"):
         rnaseq_command.append("-c")
         rnaseq_command.append(config.get("nextflow", "custom_config"))
+    elif os.path.isfile(os.path.join(os.path.dirname(sys.modules['__main__'].__file__), "qd-wrapper_nextflow.config")):
+        rnaseq_command.append("-c")
+        rnaseq_command.append(os.path.join(os.path.dirname(sys.modules['__main__'].__file__), "qd-wrapper_nextflow.config"))
+
 
     # Profile to use
     rnaseq_command.append("-profile")
@@ -139,7 +144,7 @@ def build_rnaseq_command(
     # Aligner to use
     rnaseq_command.append("--aligner")
     rnaseq_command.append(config.get("rnaseq", "aligner"))
-    #Add salmon if not using the star_salmon option
+    # Add salmon if not using the star_salmon option
     if config.get("rnaseq", "aligner") != 'star_salmon':
         rnaseq_command.append("--pseudo_aligner")
         rnaseq_command.append("salmon")
@@ -186,9 +191,12 @@ def build_rnafusion_command(config, outdir: str, logdir: str, ss_path: str, test
     )
 
     # If custom config, use it
-    if config.get("nextflow", "custom_config"):
+    if config.has_option("nextflow", "custom_config"):
         rnafusion_command.append("-c")
         rnafusion_command.append(config.get("nextflow", "custom_config"))
+    elif os.path.isfile(os.path.join(os.path.dirname(sys.modules['__main__'].__file__), "qd-wrapper_nextflow.config")):
+        rnafusion_command.append("-c")
+        rnafusion_command.append(os.path.join(os.path.dirname(sys.modules['__main__'].__file__), "qd-wrapper_nextflow.config"))
 
     # Profile to use
     rnafusion_command.append("-profile")
@@ -247,4 +255,3 @@ def start_pipe_threads(pipe_dict: dict, logger):
     for u in threads:  # Waits for all threads to finish
         u.join()
         logger.info(f"Completed the {u.name} pipeline")
-        

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -109,7 +109,7 @@ def build_rnaseq_command(
 
     # Path to main.nf
     rnaseq_command.append("run")
-    rnaseq_command.append(config.get("nextflow", "rnaseq"))
+    rnaseq_command.append(config.get("rnaseq", "main"))
 
     # Execution report
     rnaseq_command.append("-with-report")
@@ -129,13 +129,13 @@ def build_rnaseq_command(
 
 
     # Pre-downloaded references, or download from iGenomes
-    if config.has_section("rnaseq-references") and not save_reference:
+    if config.has_section("rnaseq-references") and not save_reference and not testrun:
         for option in config.options("rnaseq-references"):
             rnaseq_command.append(f"--{option}")
             rnaseq_command.append(config.get("rnaseq-references", option))
     else:
         rnaseq_command.append("--genome")
-        rnaseq_command.append(config.get("nextflow", "genome"))
+        rnaseq_command.append(config.get("rnaseq", "genome"))
 
     # Input samplesheet.csv
     if not testrun:
@@ -170,7 +170,7 @@ def build_rnafusion_command(config, outdir: str, logdir: str, ss_path: str, test
 
     # Path to main.nf
     rnafusion_command.append("run")
-    rnafusion_command.append(config.get("nextflow", "rnafusion"))
+    rnafusion_command.append(config.get("rnafusion", "main"))
 
     # Execution report
     rnafusion_command.append("-with-report")
@@ -195,10 +195,14 @@ def build_rnafusion_command(config, outdir: str, logdir: str, ss_path: str, test
 
     # Path to dependencies
     rnafusion_command.append("--genomes_base")
-    rnafusion_command.append(config.get("nextflow", "dependencies_fusion"))
+    rnafusion_command.append(config.get("rnafusion", "dependencies_fusion"))
 
     # Use filtered fusionreport fusions for fusioninspector
-    rnafusion_command.append("--fusioninspector_filter")
+    rnafusion_command.append("--fusioninspector_filter 1")
+
+    # Set fusionreport tool cutoff
+    rnafusion_command.append("--fusionreport-tool-cutoff")
+    rnafusion_command.append(config.get("rnafusion", "fusionreport_tool_cutoff"))
 
     # Input samplesheet.csv
     if not testrun:
@@ -236,3 +240,4 @@ def start_pipe_threads(pipe_dict: dict, logger):
     for u in threads:  # Waits for all threads to finish
         u.join()
         logger.info(f"Completed the {u.name} pipeline")
+        

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -74,7 +74,7 @@ def dir_to_samplesheet(scriptpath: str, fastqdir: str, strandedness: str) -> str
     return ss_path
 
 
-def sanitize_fastqdir(fastqdir: str):
+def sanitize_fastqdir(fastqdir: str) -> None:
     """
     Checks all files in a given fastq dir that assumptions about naming is met.
     For now this only checks file endings, but could be expanded to check for samples with more than 2 files.
@@ -95,7 +95,7 @@ def build_rnaseq_command(
     ss_path: str,
     testrun=False,
     save_reference=False,
-) -> dict:
+) -> dict[str, list[str]]:
     """
     Create a list with the nextflow commands to send to subprocess
 
@@ -184,7 +184,7 @@ def build_rnafusion_command(
     logdir: str,
     ss_path: str,
     testrun=False,
-) -> dict:
+) -> dict[str, list[str]]:
     """
     Create a list with the nextflow commands to send to subprocess
 
@@ -262,7 +262,7 @@ def build_rnafusion_command(
     return {"nf-core/rnafusion": rnafusion_command}
 
 
-def start_pipe_threads(pipe_dict: dict, logger):
+def start_pipe_threads(pipe_dict: dict, logger) -> None:
     """
     Takes a dict where keys are pipeline names and values are a list containing all parts of a
     command, and starts them in a separate thread using subprocess.call

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -196,6 +196,9 @@ def build_rnafusion_command(config, outdir: str, logdir: str, ss_path: str, test
     rnafusion_command.append("--genomes_base")
     rnafusion_command.append(config.get("nextflow", "dependencies_fusion"))
 
+    # Use filtered fusionreport fusions for fusioninspector
+    rnafusion_command.append("--fusioninspector_filter")
+
     # Input samplesheet.csv
     if not testrun:
         rnafusion_command.append("--input")

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -141,7 +141,8 @@ def build_rnaseq_command(
     rnaseq_command.append(config.get("rnaseq", "aligner"))
     #Add salmon if not using the star_salmon option
     if config.get("rnaseq", "aligner") != 'star_salmon':
-        rnaseq_command.append("--pseudo_aligner salmon")
+        rnaseq_command.append("--pseudo_aligner")
+        rnaseq_command.append("salmon")
 
     # Input samplesheet.csv
     if not testrun:
@@ -204,7 +205,7 @@ def build_rnafusion_command(config, outdir: str, logdir: str, ss_path: str, test
     rnafusion_command.append(config.get("rnafusion", "dependencies_fusion"))
 
     # Use filtered fusionreport fusions for fusioninspector
-    rnafusion_command.append("--fusioninspector_filter 1")
+    rnafusion_command.append("--fusioninspector_filter")
 
     # Set fusionreport tool cutoff
     rnafusion_command.append("--fusionreport-tool-cutoff")

--- a/wrapper.py
+++ b/wrapper.py
@@ -96,6 +96,7 @@ def main(
             testrun,
             save_reference,
         )
+        # Merge the rnaseq command with the other commands
         pipe_commands = pipe_commands | rnaseq_command
 
     # Build the rnafusion command and add to threads
@@ -107,6 +108,7 @@ def main(
             ss_path,
             testrun,
         )
+        # Merge the rnafusion command with the other commands
         pipe_commands = pipe_commands | rnafusion_command
 
     # Start the pipelines in separate threads

--- a/wrapper.py
+++ b/wrapper.py
@@ -14,20 +14,51 @@ from tools.helpers import (
 
 
 @click.command()
-@click.option("--fastqdir", required=True, help="Path to input directory of fastq files")
-@click.option("--outdir", required=True, help="Path to output directory")
-@click.option("--strandedness", default="reverse", help="Strandedness of seq libraries")
-@click.option("--testrun", is_flag=True, help="Run with nf-core test data")
-@click.option("--skip-rnaseq", is_flag=True, help="Skip the nf-core/rnaseq pipeline")
-@click.option("--skip-rnafusion", is_flag=True, help="Skip the nf-core/rnafusion pipeline")
-@click.option("--save-reference", is_flag=True, help="Save the genome references in outfolder")
-def main(fastqdir, outdir, strandedness, testrun, skip_rnaseq, skip_rnafusion, save_reference):
+@click.option(
+    "--fastqdir",
+    required=True,
+    help="Path to input directory of fastq files",
+)
+@click.option(
+    "--outdir",
+    required=True,
+    help="Path to output directory",
+)
+@click.option(
+    "--strandedness",
+    default="reverse",
+    help="Strandedness of seq libraries",
+)
+@click.option(
+    "--testrun",
+    is_flag=True,
+    help="Run with nf-core test data",
+)
+@click.option(
+    "--skip-rnaseq",
+    is_flag=True,
+    help="Skip the nf-core/rnaseq pipeline",
+)
+@click.option(
+    "--skip-rnafusion",
+    is_flag=True,
+    help="Skip the nf-core/rnafusion pipeline",
+)
+@click.option(
+    "--save-reference",
+    is_flag=True,
+    help="Save the genome references in outfolder",
+)
+def main(
+    fastqdir, outdir, strandedness, testrun, skip_rnaseq, skip_rnafusion, save_reference
+):
     # Set up the logger function
     now = datetime.datetime.now()
     logdir = os.path.join(outdir, "logs")
     os.makedirs(logdir, exist_ok=True)
     logfile = os.path.join(
-        logdir, "QD-rnaseq-wrapper_" + now.strftime("%y%m%d_%H%M%S") + ".log"
+        logdir,
+        "QD-rnaseq-wrapper_" + now.strftime("%y%m%d_%H%M%S") + ".log",
     )
     logger = setup_logger("qd-rnaseq", logfile)
     logger.info("Starting the RNAseq pipepline wrapper.")
@@ -57,12 +88,25 @@ def main(fastqdir, outdir, strandedness, testrun, skip_rnaseq, skip_rnafusion, s
 
     # Build the rnaseq command and add to threads
     if not skip_rnaseq:
-        rnaseq_command = build_rnaseq_command(config, outdir, logdir, ss_path, testrun, save_reference)
+        rnaseq_command = build_rnaseq_command(
+            config,
+            outdir,
+            logdir,
+            ss_path,
+            testrun,
+            save_reference,
+        )
         pipe_commands = pipe_commands | rnaseq_command
 
     # Build the rnafusion command and add to threads
     if not skip_rnafusion:
-        rnafusion_command = build_rnafusion_command(config, outdir, logdir, ss_path, testrun)
+        rnafusion_command = build_rnafusion_command(
+            config,
+            outdir,
+            logdir,
+            ss_path,
+            testrun,
+        )
         pipe_commands = pipe_commands | rnafusion_command
 
     # Start the pipelines in separate threads

--- a/wrapper.py
+++ b/wrapper.py
@@ -57,7 +57,6 @@ def main(fastqdir, outdir, strandedness, testrun, skip_rnaseq, skip_rnafusion, s
 
     # Build the rnaseq command and add to threads
     if not skip_rnaseq:
-        logger.info("Starting the nf-core/rnaseq pipeline")
         rnaseq_command = build_rnaseq_command(config, outdir, logdir, ss_path, testrun, save_reference)
         pipe_commands = pipe_commands | rnaseq_command
 

--- a/wrapper.py
+++ b/wrapper.py
@@ -50,8 +50,14 @@ from tools.helpers import (
     help="Save the genome references in outfolder",
 )
 def main(
-    fastqdir, outdir, strandedness, testrun, skip_rnaseq, skip_rnafusion, save_reference
-):
+    fastqdir: str,
+    outdir: str,
+    strandedness: str,
+    testrun: bool,
+    skip_rnaseq: bool,
+    skip_rnafusion: bool,
+    save_reference: bool,
+) -> None:
     # Set up the logger function
     now = datetime.datetime.now()
     logdir = os.path.join(outdir, "logs")


### PR DESCRIPTION
## Optimisation round 1

This PR is a small update with various improvements. No specific functionality has been added, but rather some small tweaks to make the core easier to understand and more streamlined.

### Added
- Fusion_inspect only runs on a filtered list of detected fusions. Prevents pizzly from adding thousands of fusions
- Moved logic of how threads were started to separate file
- Separated logs for rnaseq and rnafusion
- Improvements to logging
- Added possibility of specifying aligner in the config
- Nextflow config file now in repo. Might change in future to use an institutional config directly in nf-core.
- Black lining

### To test
```
git clone git@github.com:ClinicalGenomicsGBG/qd-rnaseq-wrapper.git
cd qd-rnaseq-wrapper
git checkout optimise_one
#(optional step if no conda env built)
conda env create -f conda-env/qd-rnaseq.yaml -p conda-env/qd-rnaseq
conda activate conda-env/qd-rnaseq
python wrapper.py --fastqdir /home/xlinak/inbox/test_squid/data --outdir ./test_outdir --testrun
```