### PR TITLE
Update rnafusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ using the env variable `$NXF_SINGULARITY_CACHEDIR`. This is best to have set in 
 Dependencies in the form of reference data and genome index was built using the --build_references flag. 
 In order to be able to build all dependencies, a [COSMIC](https://cancer.sanger.ac.uk/cosmic/) account is required.
 
+In the past, there has been issues with the 'STARFUSION_BUILD' step due to the EBI FTP server being overloaded.
+Hopefully this gets fixed in future releases of the rnafusion pipeline, but it is sometimes needed to restart
+the build command using the `-resume` flag ac ouple of times. 
+
 **Code for installation**
 
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ In order to be able to build all dependencies, a [COSMIC](https://cancer.sanger.
 
 In the past, there has been issues with the 'STARFUSION_BUILD' step due to the EBI FTP server being overloaded.
 Hopefully this gets fixed in future releases of the rnafusion pipeline, but it is sometimes needed to restart
-the build command using the `-resume` flag ac ouple of times. 
+the build command using the `-resume` flag a couple of times. 
 
 **Code for installation**
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Code for installation
 ```
 export NXF_SINGULARITY_CACHEDIR="/apps/bio/dependencies/nf-core/singularities"
 cd /apps/bio/repos/nf-core/nf-core-rnaseq-X.Y/
-nf-core download rnaseq --container singularity
+nf-core download rnaseq --container singularity --singularity-cache-only
 ```
 
 **Pre-downloaded references**
@@ -58,15 +58,15 @@ In order to be able to build all dependencies, a [COSMIC](https://cancer.sanger.
 ```
 export NXF_SINGULARITY_CACHEDIR="/apps/bio/dependencies/nf-core/singularities"
 cd /apps/bio/repos/nf-core/nf-core-rnafusion-X.Y.Z/
-nf-core download rnafusion --container singularity
-nextflow /apps/bio/repos/nf-core/nf-core-rnafusion-2.0.0/workflow/main.nf 
+nf-core download rnafusion --container singularity --singularity-cache-only
+nextflow /apps/bio/repos/nf-core/nf-core-rnafusion-X.Y.Z/workflow/main.nf 
     -c /apps/bio/repos/nf-core-configs/conf/medair.config 
     -profile singularity,byss 
     --build_references 
     --all
     --genomes_base /apps/bio/dependencies/nf-core/nf-core-rnafusion-X.Y.Z
     --outdir /apps/bio/dependencies/nf-core/nf-core-rnafusion-X.Y.Z
-    ---cosmic_username <username>
+    --cosmic_username <username>
     --cosmic_passwd <password>  
 ```
 

--- a/config.ini
+++ b/config.ini
@@ -10,13 +10,13 @@ strandedness = reverse
 
 [nextflow]
 #custom_config = /apps/bio/repos/nf-core-configs/conf/medair.config
-profile = singularity,byss,qd_rnaseq
-test_profile = singularity,byss,test
+profile = singularity,production,qd_rnaseq
+test_profile = singularity,production,test
 
 [rnafusion]
-main = /apps/bio/repos/nf-core/nf-core-rnafusion-2.0.0/workflow/main.nf
+main = /apps/bio/repos/nf-core/nf-core-rnafusion-2.1.0/workflow/main.nf
 #rnafusion = /home/xlinak/repos/rnafusion/main.nf
-dependencies_fusion = /apps/bio/dependencies/nf-core/nf-core-rnafusion-2.0.0
+dependencies_fusion = /apps/bio/dependencies/nf-core/nf-core-rnafusion-2.1.0
 fusionreport_tool_cutoff = 1
 readlength = 150
 

--- a/qd-wrapper_nextflow.config
+++ b/qd-wrapper_nextflow.config
@@ -42,7 +42,7 @@ profiles {
       cpus   = { check_max( 1    * task.attempt, 'cpus'   ) }
       memory = { check_max( 6.GB * task.attempt, 'memory' ) }
 
-      errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'retry' : 'finish' }
+      errorStrategy = { task.exitStatus in [143,137,104,134,139,140] ? 'retry' : 'finish' }
       maxRetries    = 2
       maxErrors     = '-1'
 
@@ -60,16 +60,11 @@ profiles {
      withLabel:process_high {
        cpus   = { check_max( 40    * task.attempt, 'cpus'    ) }
        memory = { check_max( 72.GB * task.attempt, 'memory'  ) }
-       time   = { check_max( 16.h  * task.attempt, 'time'    ) }
+       time   = { check_max( 20.h  * task.attempt, 'time'    ) }
        }
      withLabel:process_long {
        time   = { check_max( 20.h  * task.attempt, 'time'    ) }
        }
-     withName: FUSIONCATCHER {
-       cpus   = { check_max( 40    * task.attempt, 'cpus'    ) }
-       memory = { check_max( 72.GB * task.attempt, 'memory'  ) }
-       time   = { check_max( 24.h  * task.attempt, 'time'    ) }
-    }
     }
   }
 

--- a/qd-wrapper_nextflow.config
+++ b/qd-wrapper_nextflow.config
@@ -1,50 +1,39 @@
 //Profile config names for nf-core/configs
 params {
   config_profile_description = 'Cluster profile for medair (local cluster of Clinical Genomics Gothenburg)'
-  config_profile_contact = 'Clinical Genomics, Gothenburg'
-  config_profile_url = 'https://www.scilifelab.se/units/clinical-genomics-goteborg/'
+  config_profile_contact     = 'Clinical Genomics, Gothenburg'
+  config_profile_url         = 'https://www.scilifelab.se/units/clinical-genomics-goteborg/'
 }
 
 //Nextflow parameters
 singularity {
-    enabled = true
+    enabled  = true
+    cacheDir = "/apps/bio/dependencies/nf-core/singularities"
 }
 
 profiles {
-  
-  clinic {
+
+  wgs {
     process {
-      queue = 'wgs.q'
-      executor = 'sge'
-      penv = 'mpi'
+      queue                  = 'wgs.q'
+      executor               = 'sge'
+      penv                   = 'mpi'
       process.clusterOptions = '-l excl=1'
-      params.max_cpus = 40
-      params.max_time = 48.h
-      params.max_memory = 128.GB
+      params.max_cpus        = 40
+      params.max_time        = 48.h
+      params.max_memory      = 128.GB
     }
   }
 
-  research {
+  production {
     process {
-      queue = 'batch.q'
-      executor = 'sge'
-      penv = 'mpi'
+      queue                  = 'production.q'
+      executor               = 'sge'
+      penv                   = 'mpi'
       process.clusterOptions = '-l excl=1'
-      params.max_cpus = 40
-      params.max_time = 480.h
-      params.max_memory = 128.GB
-    }
-  }
-
-  byss {
-    process {
-      queue = 'test.q'
-      executor = 'sge'
-      penv = 'mpi'
-      process.clusterOptions = '-l excl=1'
-      params.max_cpus = 40
-      params.max_time = 480.h
-      params.max_memory = 128.GB
+      params.max_cpus        = 40
+      params.max_time        = 480.h
+      params.max_memory      = 128.GB
     }
   }
 
@@ -76,6 +65,11 @@ profiles {
      withLabel:process_long {
        time   = { check_max( 20.h  * task.attempt, 'time'    ) }
        }
+     withName: FUSIONCATCHER {
+       cpus   = { check_max( 40    * task.attempt, 'cpus'    ) }
+       memory = { check_max( 72.GB * task.attempt, 'memory'  ) }
+       time   = { check_max( 24.h  * task.attempt, 'time'    ) }
+    }
     }
   }
 


### PR DESCRIPTION
# Update nf-core/rnafusion version
As there is a new version of the rnafusion pipeline (2.1.0, https://github.com/nf-core/rnafusion/releases/tag/2.1.0) this PR updates which version of rnafusion is used.

Additionally, the documentation for installing new versions have been updated.

I've set this to merge to the initiate_runner branch to properly reflect the things new in this branch.