### PR TITLE
Use SLIMS bioinformatics object

### DIFF
--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -417,7 +417,7 @@ def report_results(finished_pipes: list, outdir: str, sample_name: str, config) 
 
     return copied_files
 
-def make_samplesheet(sample, fastqs: list, strandedness: str, outdir: str) -> str:
+def make_samplesheet(sample: str, fastqs: list, strandedness: str, outdir: str) -> str:
     """
     Takes a list of fastq files and a strandedness and creates a samplesheet.csv
     file with the correct information.

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -417,19 +417,17 @@ def report_results(finished_pipes: list, outdir: str, sample_name: str, config) 
 
     return copied_files
 
-def make_samplesheet(sample, fastqs, strandedness: str, outdir: str) -> str:
+def make_samplesheet(sample, fastqs: list, strandedness: str, outdir: str) -> str:
     """
     Takes a list of fastq files and a strandedness and creates a samplesheet.csv
     file with the correct information.
 
     :param sample: Name of the sample
-    :param fastqs: Object with fastq file paths
+    :param fastqs: List with fastq file paths
     :param strandedness: Strandedness of the library
     :param outfile: Path to the output file
     :return: Path to the samplesheet.csv file
     """
-    # Get all fastq paths
-    fastqs = find_fastq_paths(fastqs)
 
     # Path to samplesheet.csv
     ss_path = os.path.join(outdir, "samplesheet.csv")

--- a/tools/slims.py
+++ b/tools/slims.py
@@ -135,22 +135,22 @@ def translate_slims_info(record) -> dict:
     }
     return master
 
-def slims_records_from_sec_analysis(primary_key: int) -> list:
-    """
-    Fetch all DNA objects from slims given a secondary analysis key
 
-    :param primary_key: Primary key integer of secondary analysis
-    :return: List with all DNA objects marked with the secondary analysis key
+def slims_records_from_sec_analysis(primary_key: int, content_type: int = 6) -> list:
     """
-    return_list = []
+    Fetch all objects from slims given a secondary analysis key and content type
+
+    :param slims: A slims connection object
+    :param primary_key: Primary key integer of secondary analysis
+    :param content_type Key of content type, default is 6 (DNA)
+    :return: List with all records marked with the secondary analysis key
+    """
+
     records = slims.fetch("Content",conjunction()
                           .add(equals("cntn_cstm_secondaryAnalysis", primary_key))
-                          .add(equals("cntn_fk_contentType", 6)))
+                          .add(equals("cntn_fk_contentType", content_type)))
 
-    for record in records:
-        return_list.append(record.cntn_id.value)
-
-    return return_list
+    return records
 
 
 def find_fastq_paths(fastq_records) -> list:

--- a/tools/slims.py
+++ b/tools/slims.py
@@ -63,7 +63,7 @@ class SlimsSample:
 
         return self._bioinformatics
 
-    def add_bioinformatics(self, originalContent, fields={}):
+    def add_bioinformatics(self, original_content_pk, fields={}):
         if not self.fastqs:
             raise Exception('Can not add bioinformatics without a parent fastq record.')
 
@@ -71,7 +71,7 @@ class SlimsSample:
         fields['cntn_fk_contentType'] = 23
         fields['cntn_status'] = Status.PENDING.value
         fields['cntn_fk_location'] = 83
-        fields['cntn_fk_originalContent'] = originalContent
+        fields['cntn_fk_originalContent'] = original_content_pk
         fields['cntn_fk_user'] = ''
 
         self._bioinformatics.append(slims.add('Content', fields))
@@ -271,7 +271,7 @@ def fetch_fastq_records(content_id: str,) -> 'Record':
     return records
 
 
-def find_attached_bioinfo_objects(bioinformatics_records, original_content_pk: int, secondaryAnalysis: int) -> 'Record':
+def find_derived_bioinfo_objects(bioinformatics_records, original_content_pk: int, secondaryAnalysis: int) -> 'Record':
     """
     Find all bioinformatics objects attached to a given originalContent and secondaryAnalysis
 

--- a/tools/slims.py
+++ b/tools/slims.py
@@ -259,7 +259,7 @@ def fetch_bioinformatics_record(content_id: str, secondary_analysis: int) -> 'Re
 
 def fetch_fastq_records(content_id: str,) -> 'Record':
     """
-    Fetch a bioinformatics record from slims given a content ID
+    Fetch fastq records from slims given a content ID
 
     :param content_id: Content ID
     :return: SLIMS fastq object

--- a/tools/slims.py
+++ b/tools/slims.py
@@ -24,7 +24,7 @@ class SlimsSample:
         self.content_id = content_id
         self._dna = None
         self._fastqs = []
-        self._bioinformatics = None
+        self._bioinformatics = []
 
     @property
     def dna(self):
@@ -74,7 +74,7 @@ class SlimsSample:
         fields['cntn_fk_originalContent'] = originalContent
         fields['cntn_fk_user'] = ''
 
-        self._bioinformatics = slims.add('Content', fields)
+        self._bioinformatics.append(slims.add('Content', fields))
 
         return self._bioinformatics
 
@@ -291,7 +291,7 @@ def find_attached_bioinfo_objects(bioinformatics_records, original_content_pk: i
             attached_bioinfo_objects.append(bioinfo_obj)
 
     if len(attached_bioinfo_objects) > 1:
-        raise Exception(f"Found more than one bioinformatics object attached with secondary analysis {secondaryAnalysis}")
+        raise Exception(f"Content {original_content_pk} has more than one bioinformatics object attached with secondary analysis {secondaryAnalysis}")
 
     if len(attached_bioinfo_objects) == 0:
         return False

--- a/tools/slims.py
+++ b/tools/slims.py
@@ -74,9 +74,10 @@ class SlimsSample:
         fields['cntn_fk_originalContent'] = original_content_pk
         fields['cntn_fk_user'] = ''
 
-        self._bioinformatics.append(slims.add('Content', fields))
+        new_record = slims.add('Content', fields)
+        self._bioinformatics.append(new_record)
 
-        return self._bioinformatics
+        return new_record
 
     def refresh(self):
         self._dna = None

--- a/wrapper.py
+++ b/wrapper.py
@@ -81,7 +81,8 @@ def main(logdir: str, cleanup: bool):
 
 
     ### --- Find all slims records marked for QD-RNAseq pipeline as secondary analysis --- ###
-    all_rnaseq_samples = slims_records_from_sec_analysis(186)
+    all_rnaseq_records = slims_records_from_sec_analysis(186)
+    all_rnaseq_samples = [record.cntn_id.value for record in all_rnaseq_records]
     # 29 = WOPR
     # 186 = QD-RNA
 

--- a/wrapper.py
+++ b/wrapper.py
@@ -15,7 +15,7 @@ from tools.slims import (
     SlimsSample,
     slims_records_from_sec_analysis,
     find_fastq_paths,
-    find_attached_bioinfo_objects,
+    find_derived_bioinfo_objects,
     update_bioinformatics_record)
 
 
@@ -108,12 +108,12 @@ def main(logdir: str, cleanup: bool):
 
             # Find all bioinformatics objects for this fastq object with correct secondary analysis
             try:
-                attached_bioinfo_object = find_attached_bioinfo_objects(slimsinfo.bioinformatics, fastq.pk(), 186)
+                derived_bioinfo_object = find_derived_bioinfo_objects(slimsinfo.bioinformatics, fastq.pk(), 186)
             except Exception as e:
                 logger.error(e)
 
             # Take care of case where there is no bioinformatics object
-            if attached_bioinfo_object == False:
+            if derived_bioinfo_object == False:
                 # Create a bionformatics object and set it to "running"
                 bioinfo_fields = {
                     'cntn_cstm_secondaryAnalysis': [186],
@@ -126,8 +126,8 @@ def main(logdir: str, cleanup: bool):
                 rnaseq_samples[sample_uniqID]['state'] = 'running'
 
             # Set existing bioinfo record to 'running' and keep track of it
-            elif attached_bioinfo_object.cntn_cstm_SecondaryAnalysisState.value == 'novel':
-                new_bioinfo_record = update_bioinformatics_record(attached_bioinfo_object, fields={'cntn_cstm_SecondaryAnalysisState': 'running'})
+            elif derived_bioinfo_object.cntn_cstm_SecondaryAnalysisState.value == 'novel':
+                new_bioinfo_record = update_bioinformatics_record(derived_bioinfo_object, fields={'cntn_cstm_SecondaryAnalysisState': 'running'})
                 rnaseq_samples[sample_uniqID]['bioinformatics'] = new_bioinfo_record
                 rnaseq_samples[sample_uniqID]['state'] = 'running'
 

--- a/wrapper.py
+++ b/wrapper.py
@@ -136,9 +136,8 @@ def main(logdir: str, cleanup: bool):
                 continue
 
             # Save all the relevant fastq paths for this sample
-            if len(rnaseq_samples[sample_uniqID]) > 0:
-                all_fastq_paths = find_fastq_paths(slimsinfo.fastqs)
-                rnaseq_samples[sample_uniqID]['fastq'] = all_fastq_paths
+            all_fastq_paths = find_fastq_paths(slimsinfo.fastqs)
+            rnaseq_samples[sample_uniqID]['fastq'] = all_fastq_paths
 
     if len(rnaseq_samples) > 0:
         logger.info(f"Found {len(rnaseq_samples.keys())} sample(s) marked for QD-RNAseq pipeline. Starting the wrapper.")

--- a/wrapper.py
+++ b/wrapper.py
@@ -124,7 +124,7 @@ def main(logdir: str, cleanup: bool):
                     'cntn_cstm_runTag': runtag,
                 }
                 # Create a bioinformatics object and save it
-                new_bioinfo_record = slimsinfo.add_bioinformatics(fastq.pk(), fields=bioinfo_fields)[-1]  # Not sure if this is the right way to do this
+                new_bioinfo_record = slimsinfo.add_bioinformatics(fastq.pk(), fields=bioinfo_fields)
                 rnaseq_samples[sample_uniqID]['bioinformatics'] = new_bioinfo_record
                 rnaseq_samples[sample_uniqID]['state'] = 'running'
 

--- a/wrapper.py
+++ b/wrapper.py
@@ -126,13 +126,11 @@ def main(logdir: str, cleanup: bool):
                 # Create a bioinformatics object and save it
                 new_bioinfo_record = slimsinfo.add_bioinformatics(fastq.pk(), fields=bioinfo_fields)
                 rnaseq_samples[sample_uniqID]['bioinformatics'] = new_bioinfo_record
-                rnaseq_samples[sample_uniqID]['state'] = 'running'
 
             # Set existing bioinfo record to 'running' and keep track of it
             elif derived_bioinfo_object.cntn_cstm_SecondaryAnalysisState.value == 'novel':
                 new_bioinfo_record = update_bioinformatics_record(derived_bioinfo_object, fields={'cntn_cstm_SecondaryAnalysisState': 'running'})
                 rnaseq_samples[sample_uniqID]['bioinformatics'] = new_bioinfo_record
-                rnaseq_samples[sample_uniqID]['state'] = 'running'
 
             else:  # State != novel
                 continue

--- a/wrapper.py
+++ b/wrapper.py
@@ -112,6 +112,8 @@ def main(logdir: str, cleanup: bool):
                 derived_bioinfo_object = find_derived_bioinfo_objects(slimsinfo.bioinformatics, fastq.pk(), 186)
             except Exception as e:
                 logger.error(e)
+                continue
+                # TODO, this should mark sample as error and write the exception to slims notify
 
             # Take care of case where there is no bioinformatics object
             if derived_bioinfo_object == False:


### PR DESCRIPTION
**Priority:** High

**What this PR does:**
This PR now keeps tracks of which samples to analyses using SLIMS instead of a flat text file. It queries SLIMS for objects which are set to a specific secondary analysis. 

I've tried to keep things as general as possible so it can be used in other pipelines, but I'm sure some things slipped through. Would be good with feedback on this.

Please do think about the logic on how this SLIMS querying works and let me know any feedback.
It might be easier to just look att the wrapper directly (especially the main function) instead of just changes as it is a bit messy. 

**To test:**
I've disabled the actual nf-core pipelines from this so if you just run the wrapper itself it should just be looking through SLIMS for objects and gather infomration about it.
You can try this out with
```
conda activate conda-env/qd-rnaseq
python wrapper.py
```
Right now there are two DNA objects in SLIMS with QD-RNAseq set as Secondary Analysis pipeline. Feel free to mess around with the bioinformatics objects, but don't remove anything else as these are mRNA validation samples and therefore "live".